### PR TITLE
Making the plugin support pmd-xml features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
     <pmd.version>5.4.0</pmd.version>
     <sonar.version>4.5.4</sonar.version>
     <sonar-java.version>3.6</sonar-java.version>
+    <sonar-xml.version>1.4</sonar-xml.version>
 
     <!-- Configuration for sonar-packaging-maven-plugin -->
     <sonar.pluginKey>pmd</sonar.pluginKey>
@@ -60,6 +61,7 @@
     <sonar.pluginClass>org.sonar.plugins.pmd.PmdPlugin</sonar.pluginClass>
     <sonar.pluginDescription><![CDATA[Analyze Java code with <a href="http://pmd.sourceforge.net/">PMD</a>.]]></sonar.pluginDescription>
     <sonar.requiresPlugin>java:${sonar-java.version}</sonar.requiresPlugin>
+    <sonar.requiresPlugin>xml:${sonar-xml.version}</sonar.requiresPlugin>
   </properties>
 
   <dependencies>
@@ -80,6 +82,13 @@
       <artifactId>sonar-java-plugin</artifactId>
       <type>sonar-plugin</type>
       <version>${sonar-java.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.sonarsource.xml</groupId>
+      <artifactId>sonar-xml-plugin</artifactId>
+      <type>sonar-plugin</type>
+      <version>${sonar-xml.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -117,6 +126,25 @@
     <dependency>
       <groupId>net.sourceforge.pmd</groupId>
       <artifactId>pmd-java</artifactId>
+      <version>${pmd.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>xerces</groupId>
+          <artifactId>xercesImpl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>net.java.dev.javacc</groupId>
+          <artifactId>javacc</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.sourceforge.pmd</groupId>
+      <artifactId>pmd-xml</artifactId>
       <version>${pmd.version}</version>
       <exclusions>
         <exclusion>

--- a/src/main/java/org/sonar/plugins/pmd/PmdConstants.java
+++ b/src/main/java/org/sonar/plugins/pmd/PmdConstants.java
@@ -30,16 +30,6 @@ public final class PmdConstants {
   public static final String XPATH_EXPRESSION_PARAM = "xpath";
   public static final String XPATH_MESSAGE_PARAM = "message";
 
-  /**
-   * Key of the java version used for sources
-   */
-  public static final String JAVA_SOURCE_VERSION = "sonar.java.source";
-
-  /**
-   * Default value for property {@link #JAVA_SOURCE_VERSION}.
-   */
-  public static final String JAVA_SOURCE_VERSION_DEFAULT_VALUE = "1.5";
-
   private PmdConstants() {
   }
 }

--- a/src/main/java/org/sonar/plugins/pmd/PmdSensor.java
+++ b/src/main/java/org/sonar/plugins/pmd/PmdSensor.java
@@ -55,9 +55,7 @@ public class PmdSensor implements Sensor {
 
   private boolean hasFilesToCheck(Type type, String repositoryKey) {
     FilePredicates predicates = fs.predicates();
-    Iterable<File> files = fs.files(predicates.and(
-      predicates.hasLanguage(Java.KEY),
-      predicates.hasType(type)));
+    Iterable<File> files = fs.files(predicates.hasType(type));
     return !Iterables.isEmpty(files) && !profile.getActiveRulesByRepository(repositoryKey).isEmpty();
   }
 

--- a/src/test/java/org/sonar/plugins/pmd/PmdExecutorTest.java
+++ b/src/test/java/org/sonar/plugins/pmd/PmdExecutorTest.java
@@ -65,13 +65,12 @@ public class PmdExecutorTest {
   PmdTemplate pmdTemplate = mock(PmdTemplate.class);
   JavaResourceLocator javaResourceLocator = mock(JavaResourceLocator.class);
   Settings settings = new Settings();
-  PmdExecutor realPmdExecutor = new PmdExecutor(fileSystem, rulesProfile, pmdProfileExporter, pmdConfiguration, javaResourceLocator, settings);
+  PmdExecutor realPmdExecutor = new PmdExecutor(fileSystem, rulesProfile, pmdProfileExporter, pmdConfiguration, javaResourceLocator);
 
   @Before
   public void setUp() {
     pmdExecutor = Mockito.spy(realPmdExecutor);
     fileSystem.setEncoding(Charsets.UTF_8);
-    settings.setProperty(PmdConstants.JAVA_SOURCE_VERSION, "1.7");
   }
 
   @Test
@@ -87,8 +86,6 @@ public class PmdExecutorTest {
 
     assertThat(report).isNotNull();
 
-    // setting java source version to the default value
-    settings.removeProperty(PmdConstants.JAVA_SOURCE_VERSION);
     report = pmdExecutor.execute();
 
     assertThat(report).isNotNull();

--- a/src/test/java/org/sonar/plugins/pmd/PmdTemplateTest.java
+++ b/src/test/java/org/sonar/plugins/pmd/PmdTemplateTest.java
@@ -85,54 +85,19 @@ public class PmdTemplateTest {
     new PmdTemplate(configuration, processor).process(inputFile, rulesets, ruleContext);
   }
 
-  @Test
-  public void java12_version() {
-    assertThat(PmdTemplate.languageVersion("1.2").getLanguageVersionHandler()).isInstanceOf(Java13Handler.class);
-  }
-
-  @Test
-  public void java5_version() {
-    assertThat(PmdTemplate.languageVersion("5").getLanguageVersionHandler()).isInstanceOf(Java15Handler.class);
-  }
-
-  @Test
-  public void java6_version() {
-    assertThat(PmdTemplate.languageVersion("6").getLanguageVersionHandler()).isInstanceOf(Java16Handler.class);
-  }
-
-  @Test
-  public void java7_version() {
-    assertThat(PmdTemplate.languageVersion("7").getLanguageVersionHandler()).isInstanceOf(Java17Handler.class);
-  }
-  
-  @Test
-  public void java8_version() {
-    assertThat(PmdTemplate.languageVersion("8").getLanguageVersionHandler()).isInstanceOf(Java18Handler.class);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void should_fail_on_invalid_java_version() {
-    PmdTemplate.create("12.2", mock(ClassLoader.class), Charsets.UTF_8);
-  }
-
-  @Test
-  public void shouldnt_fail_on_valid_java_version() {
-    PmdTemplate.create("6", mock(ClassLoader.class), Charsets.UTF_8);
-  }
-
   /**
    * SONARPLUGINS-3318
    */
   @Test
   public void should_set_classloader() {
     ClassLoader classloader = mock(ClassLoader.class);
-    PmdTemplate pmdTemplate = PmdTemplate.create("6", classloader, Charsets.UTF_8);
+    PmdTemplate pmdTemplate = PmdTemplate.create(classloader, Charsets.UTF_8);
     assertThat(pmdTemplate.configuration().getClassLoader()).isEqualTo(classloader);
   }
 
   @Test
   public void should_set_encoding() {
-    PmdTemplate pmdTemplate = PmdTemplate.create("6", mock(ClassLoader.class), Charsets.UTF_16BE);
+    PmdTemplate pmdTemplate = PmdTemplate.create(mock(ClassLoader.class), Charsets.UTF_16BE);
     assertThat(pmdTemplate.configuration().getSourceEncoding()).isEqualTo("UTF-16BE");
   }
   


### PR DESCRIPTION
This adds support for recognizing XML and WSDL files in the plugin. For that, it adds the dependencies for sonar-xml plugin and the pmd-xml module.

The way it is now, the language support is decided by PMD itself, not controlled by the plugin. The language of a given file and the source version is determined by the PmdTemplate.process() method.

This enables SonarQube to verify custom XML or WSDL rules.