### PR TITLE
changed PDM site url from pmd.sourceforge.net to pmd.github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 SonarQube PMD Plugin
 ====================
 ## Description / Features
-This plugin provides coding rules from [PMD](http://pmd.sourceforge.net/).
+This plugin provides coding rules from [PMD](https://pmd.github.io/).
 
 PMD Plugin|2.0|2.1|2.2|2.3|2.4.1|2.5
 -------|---|---|---|---|---|---


### PR DESCRIPTION
The old PDM site does not seem to be online. I updated the url in readme to point to the github page https://pmd.github.io/
