### PR TITLE
catch Throwable in PMdTemmplate instead of catch Exception

### DIFF
--- a/src/main/java/org/sonar/plugins/pmd/PmdTemplate.java
+++ b/src/main/java/org/sonar/plugins/pmd/PmdTemplate.java
@@ -80,7 +80,7 @@ public class PmdTemplate {
     try {
       inputStream = new FileInputStream(file);
       processor.processSourceCode(inputStream, rulesets, ruleContext);
-    } catch (Exception e) {
+    } catch (Throwable e) {
       LOG.error("Fail to execute PMD. Following file is ignored: " + file, e);
     } finally {
       Closeables.closeQuietly(inputStream);


### PR DESCRIPTION
During code analysis in maven we get this error:

`[ERROR] Fail to execute PMD. Following file is ignored: /opt/mvn/jenkins/workspace/LAS-HEAD-Sonar/server/LVM_Drucken_Server/src/main/java/de/lvm/drucken/web/PrinterTestServlet.java
java.lang.ClassFormatError: Absent Code attribute in method that is not native or abstract in class file javax/servlet/ServletException`

ClassFormatError is not of Type Exception, so the analysis is stopped with an error. If we catch Throwable instead of Exception, the error is handled correctly.
